### PR TITLE
Fix/japanese validation messages

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -33,6 +33,7 @@
 #error_explanation ul {
   margin-bottom: 0;
   padding-left: 1.25rem;
+  text-align: left;
 }
 
 #error_explanation li {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,28 @@
  *= require_tree .
  *= require_self
  */
+
+/* Error Messages */
+#error_explanation {
+  color: #721c24;
+  background-color: #f8d7da;
+  border: 1px solid #f5c6cb;
+  padding: 0.75rem 1.25rem;
+  margin-bottom: 1rem;
+  border-radius: 0.25rem;
+}
+
+#error_explanation h2 {
+  color: #721c24;
+  font-size: 1.1rem;
+  margin-bottom: 0.5rem;
+}
+
+#error_explanation ul {
+  margin-bottom: 0;
+  padding-left: 1.25rem;
+}
+
+#error_explanation li {
+  margin-bottom: 0.25rem;
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,6 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  validates :first_name, presence: true, length: { maximum: 6 }
   validates :last_name, presence: true, length: { maximum: 6 }
+  validates :first_name, presence: true, length: { maximum: 6 }
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,4 +1,15 @@
 <div style="text-align: center; max-width: 400px; margin: 0 auto; padding: 20px;">
+  <% if resource.errors.any? %>
+    <div id="error_explanation" data-turbo-cache="false">
+      <h2>
+        <%= I18n.t("errors.messages.not_saved",
+                  count: resource.errors.count,
+                  resource: resource.class.model_name.human.downcase)
+        %>
+      </h2>
+    </div>
+  <% end %>
+
   <h1 style="font-size: 2em; margin-bottom: 30px;">新規登録</h1>
 
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,14 +1,8 @@
 <% if resource.errors.any? %>
   <div id="error_explanation" data-turbo-cache="false">
-    <h2>
-      <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
-    </h2>
     <ul>
       <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
+        <li>・<%= message %></li>
       <% end %>
     </ul>
   </div>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -61,5 +61,5 @@ ja:
       not_found: "見つかりません"
       not_locked: "ロックされていませんでした"
       not_saved:
-        one: "1つのエラーにより%{resource}を保存できませんでした:"
-        other: "%{count}個のエラーにより%{resource}を保存できませんでした:"
+        one: "下記1個の間違いがあり、%{resource}を保存できませんでした"
+        other: "下記%{count}個の間違いがあり、%{resource}を保存できませんでした"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,13 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+    attributes:
+      user:
+        email: メールアドレス
+        password: パスワード
+        first_name: 名
+        last_name: 姓
+  errors:
+    messages:
+      blank: "を入力してください"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,15 +6,24 @@ ja:
       user:
         email: メールアドレス
         password: パスワード
+        password_confirmation: パスワード(確認用)
         first_name: 名
         last_name: 姓
+    errors:
+      models:
+        user:
+          attributes:
+            first_name:
+              blank: "は6文字以内で入力してください"
+            last_name:
+              blank: "は6文字以内で入力してください"
   errors:
     messages:
       blank: "を入力してください"
       too_short: "は%{count}文字以上で入力してください"
       too_long: "は%{count}文字以下で入力してください"
       invalid: "は正しい形式で入力してください"
-      confirmation: "と確認用が一致しません"
+      confirmation: "とパスワードが一致しません"
       accepted: "を受諾してください"
       empty: "を入力してください"
       present: "は入力しないでください"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,3 +11,11 @@ ja:
   errors:
     messages:
       blank: "を入力してください"
+      too_short: "は%{count}文字以上で入力してください"
+      too_long: "は%{count}文字以下で入力してください"
+      invalid: "は正しい形式で入力してください"
+      confirmation: "と確認用が一致しません"
+      accepted: "を受諾してください"
+      empty: "を入力してください"
+      present: "は入力しないでください"
+      taken: "はすでに存在します"


### PR DESCRIPTION
# 概要
新規登録フォーム入力時エラー情報を修正
## 内容

- [x] config/locales/ja.ymlを作成しました
- [x] エラーメッセージが赤く表示されるようにid="error_explanation"にCSSを追加しました
- [x] 新規登録フォーム入力時エラー情報を個別表示するようにしました
closes #48 